### PR TITLE
Update Makefile to automatically create necessary directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 install:
-	@mv ../gnome-shell-extension-stealmyfocus ~/.local/share/gnome-shell/extensions/steal-my-focus@kagesenshi.org
+	@mkdir -p ~/.local/share/gnome-shell/extensions && mv ../gnome-shell-extension-stealmyfocus ~/.local/share/gnome-shell/extensions/steal-my-focus@kagesenshi.org


### PR DESCRIPTION
Old Makefile didn't work if   `~/.local/share/gnome-shell/extensions` didn't exist, i.e. if no previous extensions where installed.